### PR TITLE
Fix Openpose and Segmentation

### DIFF
--- a/custom_nodes/annotator/__init__.py
+++ b/custom_nodes/annotator/__init__.py
@@ -14,12 +14,15 @@ def img_tensor_to_np(img_tensor):
 
 def common_annotator_call(annotator_callback, tensor_image, *args):
     call_result = annotator_callback(img_tensor_to_np(tensor_image), *args)
-    if type(call_result) is tuple:
-        for i in range(len(call_result)):
-            call_result[i] = HWC3(call_result[i])
-    else:
-        call_result = HWC3(call_result)
-    return call_result
+    if type(annotator_callback) is openpose.OpenposeDetector:
+        return (HWC3(call_result[0]),call_result[1])
+    # if type(call_result) is tuple:
+    #     for i in range(len(call_result)):
+    #         call_result[i] = HWC3(call_result[i])
+    # else:
+    #     call_result = HWC3(call_result)
+    return HWC3(call_result)
+
 
 class CannyEdgePreprocesor:
     @classmethod

--- a/custom_nodes/annotator/uniformer/__init__.py
+++ b/custom_nodes/annotator/uniformer/__init__.py
@@ -14,7 +14,7 @@ class UniformerDetector:
         if not os.path.exists(modelpath):
             from basicsr.utils.download_util import load_file_from_url
             load_file_from_url(checkpoint_file, model_dir=annotator_ckpts_path)
-        config_file = os.path.join(os.path.dirname(annotator_ckpts_path), "uniformer", "exp", "upernet_global_small", "config.py")
+        config_file = os.path.join(os.path.dirname(annotator_ckpts_path).replace("models", "custom_nodes/annotator"), "uniformer", "exp", "upernet_global_small", "config.py")
         self.model = init_segmentor(config_file, modelpath).cuda()
 
     def __call__(self, img):


### PR DESCRIPTION
Openpose: Tuples are not assignable, so that code is kinda weird. But even if tuples were assignable, that bit wouldn't work because the second element is a dictionary containing the node positions returned by openpose, which cannot be passed into HWC3. I don't know if the tuple code was supposed to be used for the two Midas processors, which currently do not work anyways, so I just commented it out. All other processors work without the tuple thing (as far as I can see).
Segemenation (Uniformer): Path for the config was pointing to the models directory instead of the cutsom_noes/annotator directory.